### PR TITLE
Remove PrintPacketTags statement in NS3Netsim

### DIFF
--- a/NS3Mosaik/mosaik_api/src/NS3Netsim.cpp
+++ b/NS3Mosaik/mosaik_api/src/NS3Netsim.cpp
@@ -81,7 +81,6 @@ ExtractInformationFromPacketAndSendToUpperLayer (Ptr<Socket> socket)
   uint32_t srcNodeId = mapIpv4NodeId[srcIpv4Address];
   Ptr<Node> srcNode =  NodeList::GetNode(srcNodeId);
   
-  packet->PrintPacketTags(std::cout);
 
   packet->RemoveAllPacketTags ();
   packet->RemoveAllByteTags ();


### PR DESCRIPTION
Remove PrintPacketTags statement in NS3Netsim.